### PR TITLE
Add Remio to local-first applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 
 - [Actual](https://actualbudget.com): Actual is a super fast privacy-focused app for managing your finances
 - [AFFiNE](https://affine.pro): AFFiNE is a next-gen knowledge base that brings planning, sorting and creating all together. Privacy first, open-source, customizable and ready to use.
+- [Remio](https://remio.ai): Local-first AI memory and knowledge base desktop app that parses files, webpages, recordings, emails, messages, images, and notes into local indexes and vectors for fast personal context retrieval.
 - [Bangle-io](https://github.com/bangle-io/bangle-io): A web only WYSIWYG note taking app that saves notes locally in markdown format.
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.


### PR DESCRIPTION
Adds Remio as a local-first AI memory and knowledge base desktop app.

Remio fits the Applications section because it keeps the knowledge workflow local-first while parsing files, webpages, recordings, emails, messages, images, and notes into local indexes and vectors for fast personal context retrieval.