### PR TITLE
Add Quota Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.
 - [Volon](https://github.com/danielgolden/volon): Volón is a plain text, markdown-focused, local-first notes app with text-editing keyboard shortcuts.
+- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.
   
 *Libraries*
 


### PR DESCRIPTION
Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser; tokens never leave the user's machine.

- Live demo (mock mode, no credentials): https://ryan-knowone.github.io/quota-dashboard/?mock=1
- Repo: https://github.com/ryan-knowone/quota-dashboard

Proposed entry under Applications > Projects:
- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.