### PR TITLE
Add Quota Dashboard to Applications > Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.
 - [Volon](https://github.com/danielgolden/volon): Volón is a plain text, markdown-focused, local-first notes app with text-editing keyboard shortcuts.
+- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.
   
 *Libraries*
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.
 - [Volon](https://github.com/danielgolden/volon): Volón is a plain text, markdown-focused, local-first notes app with text-editing keyboard shortcuts.
-- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only, privacy-first dashboard for AI subscription quota (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser as a static site; tokens never leave the user's machine.
+- [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard): Local-only web dashboard for AI subscription quota across Claude Code Max, Kimi, and Z.ai. Runs a small local Node server so tokens stay on the user's machine and are never persisted.
   
 *Libraries*
 


### PR DESCRIPTION
I previously closed PR #37 because the project was mock-data only. It now has real API integrations via a local Node server, so I'm re-submitting.

Add [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) to the Applications > Projects section.

It's a local-only web dashboard for tracking AI subscription quota across Claude Code Max, Kimi, and Z.ai. The app runs a small local Node server so tokens stay on the user's machine and are never persisted. Open source, zero runtime dependencies, `npm start`.

Live demo (no credentials needed): https://ryan-knowone.github.io/quota-dashboard/?mock=1