### PR TITLE
Add Oats to applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 - [Actual](https://actualbudget.com): Actual is a super fast privacy-focused app for managing your finances
 - [AFFiNE](https://affine.pro): AFFiNE is a next-gen knowledge base that brings planning, sorting and creating all together. Privacy first, open-source, customizable and ready to use.
 - [Bangle-io](https://github.com/bangle-io/bangle-io): A web only WYSIWYG note taking app that saves notes locally in markdown format.
+- [OATS](https://github.com/ariso-ai/oats): Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and a fully offline on-device mode.
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.
 - [Volon](https://github.com/danielgolden/volon): Volón is a plain text, markdown-focused, local-first notes app with text-editing keyboard shortcuts.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A list of projects built following the [local-first concept](https://www.inkands
 - [Actual](https://actualbudget.com): Actual is a super fast privacy-focused app for managing your finances
 - [AFFiNE](https://affine.pro): AFFiNE is a next-gen knowledge base that brings planning, sorting and creating all together. Privacy first, open-source, customizable and ready to use.
 - [Bangle-io](https://github.com/bangle-io/bangle-io): A web only WYSIWYG note taking app that saves notes locally in markdown format.
-- [OATS](https://github.com/ariso-ai/oats): Open-source macOS menu bar meeting-notes app with live transcription, speaker labels, AI summaries, and a fully offline on-device mode.
+- [OATS](https://github.com/ariso-ai/oats): Open-source local-first macOS meeting-notes app with live transcription, speaker labels, AI summaries, and a fully offline on-device mode.
 - [TidGi](https://github.com/tiddly-gittly/TidGi-Desktop): Customizable personal knowledge-base with git as backup manager.
 - [TiddlyWiki5](https://github.com/Jermolene/TiddlyWiki5): A self-contained JavaScript wiki for the browser, Node.js, AWS Lambda etc, works in local-first.
 - [Volon](https://github.com/danielgolden/volon): Volón is a plain text, markdown-focused, local-first notes app with text-editing keyboard shortcuts.


### PR DESCRIPTION
## Summary

- Add Oats to Applications > Projects.
- Oats is an open-source local-first macOS meeting-notes app with an optional fully offline on-device mode for recording, transcription, diarization, and summaries.

## Checks

- git diff --check
